### PR TITLE
[1.4.0] Update release GHA, and minor Dockerfile fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*-d2iq.*"
+
+# Because variables are not exported, they are not visible by child processes, e.g. make
+env:
+  registry: ghcr.io/mesosphere
+
+jobs:
+  release:
+    name: Release
+    runs-on:
+      - ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container image
+        run: |
+          make \
+            REGISTRY=${{ env.registry }} \
+            VERSION=${{ github.ref_name }} \
+            docker-build-csi \
+            docker-push-csi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ RUN tdnf install -y xfsprogs e2fsprogs udev && \
 WORKDIR /opt/vcloud/bin
 
 ARG CSI_BUILD_DIR
-ADD ${CSI_BUILD_DIR}/cloud-director-named-disk-csi-driver .
+COPY ${CSI_BUILD_DIR}/cloud-director-named-disk-csi-driver .
 # copy multiple small files at 1 time to create a single layer
-COPY LICENSE.txt NOTICE.txt open_source_license.txt /opt/vcloud/bin/
-
-RUN chmod +x /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+COPY LICENSE.txt NOTICE.txt open_source_license.txt .
 
 # USER nobody
 ENTRYPOINT ["/bin/bash", "-l", "-c"]


### PR DESCRIPTION
## Description
- Update the release GHA to use the make targets available in 1.4.0
- Consistently use WORKDIR in the Dockerfile
