### PR TITLE
build: run tdnf update to pick up CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM photon:4.0-20230506
 
-RUN tdnf install -y xfsprogs e2fsprogs udev && \
+RUN tdnf -y update && \
+    tdnf install -y xfsprogs e2fsprogs udev && \
     tdnf clean all
 
 WORKDIR /opt/vcloud/bin


### PR DESCRIPTION
## Description
Update packages at build time to pick up CVE fixes

See results with a test image:
```
trivy image --severity CRITICAL,HIGH ghcr.io/mesosphere/cloud-director-named-disk-csi-driver:1.4.0-d2iq.1
2023-12-20T13:46:27.590-0800    INFO    Vulnerability scanning is enabled
2023-12-20T13:46:27.590-0800    INFO    Secret scanning is enabled
2023-12-20T13:46:27.590-0800    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-12-20T13:46:27.590-0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2023-12-20T13:46:31.223-0800    INFO    Detected OS: photon
2023-12-20T13:46:31.223-0800    INFO    Detecting Photon Linux vulnerabilities...
2023-12-20T13:46:31.225-0800    INFO    Number of language-specific files: 1
2023-12-20T13:46:31.225-0800    INFO    Detecting gobinary vulnerabilities...

ghcr.io/mesosphere/cloud-director-named-disk-csi-driver:1.4.0-d2iq.1 (photon 4.0)

Total: 0 (HIGH: 0, CRITICAL: 0)
``` 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## Testing Done
Please provide a screenshot of the testing results for the code change in this Pull Request. Verify that this pull request's code change will not affect CSI's normal operation


## Issue
If applicable, please reference the relevant issue

Fixes #